### PR TITLE
Patch for improved edge detection

### DIFF
--- a/liveedgedetection/src/main/java/com/adityaarora/liveedgedetection/constants/ScanConstants.java
+++ b/liveedgedetection/src/main/java/com/adityaarora/liveedgedetection/constants/ScanConstants.java
@@ -10,4 +10,10 @@ public class ScanConstants {
     public static final String IMAGE_DIR = "imageDir";
     public static final int HIGHER_SAMPLING_THRESHOLD = 2200;
 
+    public static int KSIZE_BLUR = 3;
+    public static int KSIZE_CLOSE = 10;
+    public static final int CANNY_THRESH_L = 85;
+    public static final int CANNY_THRESH_U = 185;
+    public static final int TRUNC_THRESH = 150;
+    public static final int CUTOFF_THRESH = 155;
 }

--- a/liveedgedetection/src/main/java/com/adityaarora/liveedgedetection/view/ScanSurfaceView.java
+++ b/liveedgedetection/src/main/java/com/adityaarora/liveedgedetection/view/ScanSurfaceView.java
@@ -74,7 +74,6 @@ public class ScanSurfaceView extends FrameLayout implements SurfaceHolder.Callba
             requestLayout();
             openCamera();
             this.camera.setPreviewDisplay(holder);
-            setPreviewCallback();
         } catch (IOException e) {
             Log.e(TAG, e.getMessage(), e);
         }


### PR DESCRIPTION
Just OTSU/Binary thresholding is not enough.
Following steps drastically improve the edge detection.
1. First blur and normalize the image for uniformity,
2. Truncate light-gray to white and normalize,
3. Apply canny edge detection,
4. Cutoff weak edges,
5. Apply closing(morphology), then proceed to finding contours.
Also converting the contours to their Convex Hulls will remove minor nuances in the contour.
